### PR TITLE
fix: include param.h in eval.h to resolve incomplete type error with gcc 15

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -32,6 +32,7 @@
 struct edf_t;
 
 struct param_t;
+#include "param.h"
 
 //
 // Helper to parse command syntax


### PR DESCRIPTION
gcc 15.2.0 (used in latest conda/jupyter base images) is stricter about 
incomplete types. eval.h forward-declares param_t but uses it in 
std::vector<param_t> at line 246, which requires the full definition.

Fix: add #include "param.h" after the forward declaration on line 34.

This fixes the Dockerfile.lunapi build which was failing at R CMD INSTALL luna.